### PR TITLE
feat(广告管理): 重构广告单元列表功能并添加模板绑定详情

### DIFF
--- a/src/Http/Controllers/WechatOpenPlatformAuthorizerController.php
+++ b/src/Http/Controllers/WechatOpenPlatformAuthorizerController.php
@@ -81,10 +81,10 @@ class WechatOpenPlatformAuthorizerController extends BaseAdminController
                     $actions->append(new SettingPrefetchDomainAction());
                     $actions->append(new SettingPrivacyAction());
                     $actions->append(new GetTradeManageAction());
-                    $actions->append(new GetAdUnitListAction());
                 }
                 $actions->append(new SetShareRatioAction(SetShareRatioAction::FROM_AUTHORIZE));
                 $actions->append(new OpenPublisherAction());
+                $actions->append(new GetAdUnitListAction());
             });
 
             $grid->tools(function (Grid\Tools $tools) {

--- a/src/Libraries/MpClient.php
+++ b/src/Libraries/MpClient.php
@@ -4,6 +4,8 @@ namespace Shanjing\DcatWechatOpenPlatform\Libraries;
 
 use EasyWeChat\MiniApp\Application;
 
+use function Pest\Laravel\json;
+
 class MpClient
 {
     /**
@@ -392,14 +394,20 @@ class MpClient
     }
 
     /**
-     * 获取广告单元列表
+     * 获取原生模板广告自定义模板绑定情况
      *
-     * @doc https://developers.weixin.qq.com/doc/oplatform/openApi/OpenApiDoc/ams/ad-unit/AgencyGetAdUnitList.html
+     * @param array $params 请求参数
+     *   - page: 返回第几页数据
+     *   - page_size: 当页返回数据条数
+     *   - ad_slot: 广告位类型名称
+     *   - tmpl_id: 模板广告单元ID（可选）
+     *   - is_return_tmpl_bind_list: 是否返回该模板广告单元ID绑定的商户广告单元信息（可选）
+     * @doc https://developers.weixin.qq.com/doc/oplatform/openApi/OpenApiDoc/ams/ad-mgnt/GetAgencyTmplIdList.html
      * @author Hailong Tian <tianhailong@shanjing-inc.com>
      */
-    public function getAdUnitList()
+    public function getAgencyTmplIdList($params)
     {
-        $response = $this->client->postJson('/wxa/operationams?action=agency_get_adunit_list');
+        $response = $this->client->postJson('/wxa/operationams?action=agency_get_tmpl_id_list', $params);
         return $response->toArray();
     }
 }


### PR DESCRIPTION
重构广告单元列表功能，将接口从`getAdUnitList`改为`getAgencyTmplIdList`以支持更多参数 在表单中添加模板ID选择框，优化用户体验
展示模板绑定详情，包括绑定广告单元的状态信息