### PR TITLE
feat(小程序): 添加模板广告单元绑定查询功能

### DIFF
--- a/src/Http/routes.php
+++ b/src/Http/routes.php
@@ -4,6 +4,7 @@ use Shanjing\DcatWechatOpenPlatform\Http\Controllers;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/wechat/open-platform/mini-program/{authorizerId}/manage', [Controllers\MiniProgramController::class, 'manage']);
+Route::get('/wechat/open-platform/mini-program/{authorizerId}/template-bind-list', [Controllers\MiniProgramController::class, 'getTemplateBindList']);
 Route::get('/wechat/open-platform/template/draft-list', [Controllers\WechatOpenPlatformTemplateController::class, 'draftList']);
 
 Route::resource('/wechat/open-platform/list', Controllers\WechatOpenPlatformController::class);

--- a/src/Libraries/MpClient.php
+++ b/src/Libraries/MpClient.php
@@ -407,7 +407,29 @@ class MpClient
      */
     public function getAgencyTmplIdList($params)
     {
-        $response = $this->client->postJson('/wxa/operationams?action=agency_get_tmpl_id_list', $params);
-        return $response->toArray();
+        $response = $this->client->postJson('/wxa/operationams?action=get_agency_ad_unit_list', $params);
+        $result   = $response->toArray();
+
+        $errorMessages = [
+            0 => 'ok',
+            -202 => '内部错误，可在一段时间后重试',
+            1700 => '参数错误，请检验输入参数是否符合文档说明',
+            1701 => '参数错误，请检验输入参数是否符合文档说明',
+            1735 => '商户未完成协议签署流程，请完成签约操作',
+            1737 => '操作过快，请等待一分钟后重新操作',
+            1807 => '无效流量主，请通过开通流量主接口为该appid开通流量主',
+            2009 => '无效流量主，请通过开通流量主接口为该appid开通流量主',
+            2056 => '服务商未在变现专区开通账户，请在第三方平台页面的变现专区开通服务'
+        ];
+        
+        $errmsg  = $result['err_msg'] ?? $result['errmsg'] ?? '';
+        $errcode = $result['errcode'] ?? $result['ret'] ?? -1;
+        $message = $errorMessages[$errcode] ?? $errmsg;
+        $message = $message ?: "未知错误（错误码：{$errcode}）";
+
+        $result['errcode'] = $errcode;
+        $result['errmsg']  = $message;
+
+        return $result;
     }
 }


### PR DESCRIPTION
新增模板广告单元绑定查询功能，包括：
1. 添加新路由用于获取模板绑定列表
2. 修改MpClient错误处理逻辑
3. 实现动态查询模板绑定详情的表单和控制器方法
4. 添加JavaScript实现前端动态加载绑定详情